### PR TITLE
Prepare Atlas CLI for crates.io publication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,18 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.1.0] - 2025-06-05
+
+### Added
+- Initial release of Atlas CLI
+- Support for creating C2PA manifests for ML models and datasets
+- Cryptographic signing capabilities
+- Multiple storage backends (MongoDB, filesystem, Rekor)
+- Model format support (ONNX, TensorFlow, PyTorch, Keras)
+- TEE attestation support (Intel TDX)
+- Cross-reference linking between manifests
+- Manifest verification and validation

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,25 @@
 name = "atlas-cli"
 version = "0.1.0"
 edition = "2021"
+description = "Machine Learning Lifecycle & Transparency Manager - Create and verify manifests for ML models and datasets"
+documentation = "https://docs.rs/atlas-cli"
+homepage = "https://github.com/IntelLabs/atlas-cli"
+repository = "https://github.com/IntelLabs/atlas-cli"
+readme = "README.md"
+license = "Apache-2.0"
+keywords = ["c2pa", "machine-learning", "provenance", "transparency", "cli"]
+categories = ["command-line-utilities", "science", "cryptography"]
+exclude = [
+    "/.github/*",
+    "/examples/*",
+    "/tests/*",
+    "/.gitignore",
+    "/Makefile",
+]
+
+[[bin]]
+name = "atlas-cli"
+path = "src/main.rs"
 
 [features]
 default = []

--- a/README.md
+++ b/README.md
@@ -19,14 +19,51 @@ A command-line interface tool for creating, managing, and verifying Content Prov
 - **Format Support**: Work with models in ONNX, TensorFlow, PyTorch, and Keras formats
 - **TEE Attestation**: Optional support for Trusted Execution Environment (TDX) integration
 
-## Quick Installation
+## Installation
+
+### Prerequisites
+
+- Rust toolchain (1.70 or later) - [Install Rust](https://rustup.rs/)
+- OpenSSL development libraries
+- (Optional) Protobuf compiler for TDX support
+
+## Install Methods
+
+### Install from crates.io
+
+The simplest way to install Atlas CLI is using cargo:
+
+```bash
+cargo install atlas-cli
+```
+#### Install with Specific Features
+##### With TDX Attestation Support:
+
+```bash
+# First install protobuf compiler
+# Ubuntu/Debian:
+sudo apt install protobuf-compiler
+
+# Then install with TDX feature
+cargo install atlas-cli --features with-tdx
+```
+#### Install from Source
 
 ```bash
 # Clone repositories
 git clone https://github.com/IntelLabs/atlas-cli
+cd atlas-cli
 
-# Build CLI
-cd atlas-cli && cargo build
+# Build and install
+cargo install --path .
+
+# Or build without installing
+cargo build --release
+# Binary will be at ./target/release/atlas-cli
+
+# To update to the latest version:
+cargo install atlas-cli --force
+
 ```
 
 ## Documentation
@@ -62,3 +99,5 @@ If you use Atlas CLI in your research or work, please cite our paper:
 
 - **Paper**: [Atlas: A Framework for ML Lifecycle Provenance & Transparency](https://arxiv.org/abs/2502.19567v1)
 - **Blog Post**: [Building Trust in AI: An End-to-End Approach for the Machine Learning Lifecycle](https://community.intel.com/t5/Blogs/Tech-Innovation/Artificial-Intelligence-AI/Building-Trust-in-AI-An-End-to-End-Approach-for-the-Machine/post/1648746)
+- **Documentation**: [docs.rs/atlas-cli]
+- **Crate**: [crates.io/crates/atlas-cli]

--- a/src/error/mod.rs
+++ b/src/error/mod.rs
@@ -2,7 +2,21 @@ mod types;
 
 pub use types::{Error, Result};
 
-/// Format error for display to the user
+/// Format an error for display to the user
+///
+/// # Examples
+///
+/// ```
+/// use atlas_cli::error::{Error, format_error};
+///
+/// let error = Error::Validation("Invalid input".to_string());
+/// let formatted = format_error(&error);
+/// assert_eq!(formatted, "Validation error: Invalid input");
+///
+/// let io_error = Error::Storage("Connection failed".to_string());
+/// let formatted = format_error(&io_error);
+/// assert_eq!(formatted, "Storage error: Connection failed");
+/// ```
 pub fn format_error(error: &Error) -> String {
     error.to_string()
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,36 @@
+//! # Atlas CLI
+//!
+//! Machine Learning (ML) Lifecycle & Transparency Manager
+//!
+//! A command-line interface tool for creating, managing, and verifying Content Provenance
+//! and Authenticity (C2PA) manifests for machine learning models, datasets, and related artifacts.
+//!
+//! ## Installation
+//!
+//! ```bash
+//! cargo install atlas-cli
+//! ```
+//!
+//! ## Quick Start
+//!
+//! Create a model manifest:
+//! ```bash
+//! atlas-cli model create \
+//!     --paths=model.onnx \
+//!     --ingredient-names="Main Model" \
+//!     --name="My Model" \
+//!     --author-org="My Organization" \
+//!     --author-name="My Name" \
+//!     --print
+//! ```
+//!
+//! For more examples and detailed documentation, see:
+//! - [User Guide](https://github.com/IntelLabs/atlas-cli/blob/main/docs/USER_GUIDE.md)
+//! - [Examples](https://github.com/IntelLabs/atlas-cli/blob/main/docs/EXAMPLES.md)
+//! - [Development Guide](https://github.com/IntelLabs/atlas-cli/blob/main/docs/DEVELOPMENT.md)
+
+#![doc(html_root_url = "https://docs.rs/atlas-cli/0.1.0")]
+
 pub mod cc_attestation;
 pub mod cli;
 pub mod error;
@@ -37,6 +70,17 @@ impl Default for Config {
 }
 
 /// Initialize logging for the CLI
+///
+/// # Examples
+///
+/// ```
+/// use atlas_cli::init_logging;
+///
+/// // Initialize with default settings
+/// let result = init_logging();
+/// // Note: This might fail if already initialized
+/// assert!(result.is_ok() || result.is_err());
+/// ```
 pub fn init_logging() -> Result<()> {
     env_logger::try_init().map_err(|e| Error::InitializationError(e.to_string()))
 }

--- a/src/manifest/mod.rs
+++ b/src/manifest/mod.rs
@@ -32,7 +32,25 @@ pub use utils::{
     determine_manifest_type, manifest_type_to_str, manifest_type_to_string, parse_manifest_type,
 };
 
-// Common manifest operations that might be shared between dataset and model
+/// Validate that a hash string is in the correct format
+///
+/// # Examples
+///
+/// ```
+/// use atlas_cli::manifest::validate_manifest_hash;
+///
+/// // Valid 64-character hex string
+/// let valid_hash = "a".repeat(64);
+/// assert!(validate_manifest_hash(&valid_hash).is_ok());
+///
+/// // Invalid: wrong length
+/// let short_hash = "abc123";
+/// assert!(validate_manifest_hash(&short_hash).is_err());
+///
+/// // Invalid: non-hex characters
+/// let invalid_chars = "g".repeat(64);
+/// assert!(validate_manifest_hash(&invalid_chars).is_err());
+/// ```
 pub fn validate_manifest_hash(hash: &str) -> Result<()> {
     if !hash.chars().all(|c| c.is_ascii_hexdigit()) {
         return Err(crate::error::Error::Validation(
@@ -527,7 +545,28 @@ pub fn verify_manifest_link(
     }
 }
 
-/// Validate manifest ID format
+/// Validate a manifest ID format
+///
+/// # Examples
+///
+/// ```
+/// use atlas_cli::manifest::validate_manifest_id;
+/// use uuid::Uuid;
+///
+/// // Valid UUID
+/// let uuid = Uuid::new_v4().to_string();
+/// assert!(validate_manifest_id(&uuid).is_ok());
+///
+/// // Valid C2PA URN
+/// let urn = format!("urn:c2pa:{}", uuid);
+/// assert!(validate_manifest_id(&urn).is_ok());
+///
+/// // Invalid: empty string
+/// assert!(validate_manifest_id("").is_err());
+///
+/// // Valid: alphanumeric ID
+/// assert!(validate_manifest_id("model-123").is_ok());
+/// ```
 pub fn validate_manifest_id(id: &str) -> Result<()> {
     // Basic validation
     if id.is_empty() {
@@ -598,7 +637,27 @@ pub fn validate_manifest_id(id: &str) -> Result<()> {
     Ok(())
 }
 
-/// Ensure ID is in C2PA URN format
+/// Ensure an ID is in C2PA URN format
+///
+/// # Examples
+///
+/// ```
+/// use atlas_cli::manifest::ensure_c2pa_urn;
+/// use uuid::Uuid;
+///
+/// // UUID gets converted to URN
+/// let uuid = Uuid::new_v4().to_string();
+/// let urn = ensure_c2pa_urn(&uuid);
+/// assert!(urn.starts_with("urn:c2pa:"));
+///
+/// // Already a URN remains unchanged
+/// let existing_urn = "urn:c2pa:12345678-1234-1234-1234-123456789012";
+/// assert_eq!(ensure_c2pa_urn(existing_urn), existing_urn);
+///
+/// // Non-UUID gets new UUID generated
+/// let result = ensure_c2pa_urn("custom-id");
+/// assert!(result.starts_with("urn:c2pa:"));
+/// ```
 pub fn ensure_c2pa_urn(id: &str) -> String {
     if id.starts_with("urn:c2pa:") {
         id.to_string() // Already in correct format
@@ -613,6 +672,22 @@ pub fn ensure_c2pa_urn(id: &str) -> String {
 }
 
 /// Extract UUID from a C2PA URN
+///
+/// # Examples
+///
+/// ```
+/// use atlas_cli::manifest::extract_uuid_from_urn;
+/// use uuid::Uuid;
+///
+/// let uuid = Uuid::new_v4();
+/// let urn = format!("urn:c2pa:{}", uuid);
+///
+/// let extracted = extract_uuid_from_urn(&urn).unwrap();
+/// assert_eq!(extracted, uuid);
+///
+/// // Invalid URN format
+/// assert!(extract_uuid_from_urn("invalid:urn").is_err());
+/// ```
 pub fn extract_uuid_from_urn(urn: &str) -> Result<Uuid> {
     let parts: Vec<&str> = urn.split(':').collect();
 

--- a/src/storage/traits.rs
+++ b/src/storage/traits.rs
@@ -6,6 +6,23 @@ use std::any::Any;
 use std::fmt;
 use std::path::PathBuf;
 
+/// Represents metadata about a stored manifest
+///
+/// # Examples
+///
+/// ```
+/// use atlas_cli::storage::traits::{ManifestMetadata, ManifestType};
+///
+/// let metadata = ManifestMetadata {
+///     id: "model-123".to_string(),
+///     name: "My Model".to_string(),
+///     manifest_type: ManifestType::Model,
+///     created_at: "2025-01-23T12:00:00Z".to_string(),
+/// };
+///
+/// assert_eq!(metadata.id, "model-123");
+/// assert_eq!(metadata.manifest_type, ManifestType::Model);
+/// ```
 #[derive(Clone, Serialize, Deserialize)]
 pub struct ManifestMetadata {
     pub id: String,
@@ -30,6 +47,35 @@ pub enum ManifestType {
     Unknown,
 }
 
+/// Represents the location and verification info for an artifact
+///
+/// # Examples
+///
+/// ```no_run
+/// use atlas_cli::storage::traits::ArtifactLocation;
+/// use std::path::PathBuf;
+///
+/// // Create from a file path
+/// let path = PathBuf::from("model.onnx");
+/// let location = ArtifactLocation::new(path).unwrap();
+///
+/// // Verify the file hasn't changed
+/// assert!(location.verify().unwrap());
+/// ```
+///
+/// ```
+/// use atlas_cli::storage::traits::ArtifactLocation;
+/// use std::path::PathBuf;
+///
+/// // Create manually
+/// let location = ArtifactLocation {
+///     url: "file:///path/to/file".to_string(),
+///     file_path: Some(PathBuf::from("/path/to/file")),
+///     hash: "a".repeat(64),
+/// };
+///
+/// assert!(location.file_path.is_some());
+/// ```
 #[derive(Clone, Serialize, Deserialize)]
 pub struct ArtifactLocation {
     pub url: String,

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -2,7 +2,25 @@ use crate::error::{Error, Result};
 use std::fs::{self, File, OpenOptions};
 use std::path::{Path, PathBuf};
 
-/// Ensures the path is not a symlink or hard link unless explicitly allowed
+/// Ensures a file path is safe to use (not a symlink or hard link unless allowed)
+///
+/// # Examples
+///
+/// ```no_run
+/// use atlas_cli::utils::safe_file_path;
+/// use std::path::Path;
+///
+/// let path = Path::new("/tmp/safe_file.txt");
+///
+/// // Check path without allowing symlinks
+/// match safe_file_path(&path, false) {
+///     Ok(safe_path) => println!("Path is safe: {:?}", safe_path),
+///     Err(e) => println!("Path is not safe: {}", e),
+/// }
+///
+/// // Allow symlinks
+/// let _ = safe_file_path(&path, true);
+/// ```
 pub fn safe_file_path(path: &Path, allow_symlinks: bool) -> Result<PathBuf> {
     // Check if the file exists
     if path.exists() {
@@ -60,12 +78,49 @@ fn is_safe_symlink_target(target: &Path) -> bool {
 }
 
 /// Safely opens a file for reading
+///
+/// # Examples
+///
+/// ```no_run
+/// use atlas_cli::utils::safe_open_file;
+/// use std::path::Path;
+/// use std::io::Read;
+///
+/// let path = Path::new("example.txt");
+///
+/// match safe_open_file(&path, false) {
+///     Ok(mut file) => {
+///         let mut contents = String::new();
+///         file.read_to_string(&mut contents).unwrap();
+///         println!("File contents: {}", contents);
+///     }
+///     Err(e) => eprintln!("Error opening file: {}", e),
+/// }
+/// ```
 pub fn safe_open_file(path: &Path, allow_symlinks: bool) -> Result<File> {
     let safe_path = safe_file_path(path, allow_symlinks)?;
     File::open(&safe_path).map_err(Error::from)
 }
 
 /// Safely creates a file for writing
+///
+/// # Examples
+///
+/// ```no_run
+/// use atlas_cli::utils::safe_create_file;
+/// use std::path::Path;
+/// use std::io::Write;
+///
+/// let path = Path::new("/tmp/new_file.txt");
+///
+/// match safe_create_file(&path, false) {
+///     Ok(mut file) => {
+///         file.write_all(b"Hello, World!").unwrap();
+///         println!("File created successfully");
+///     }
+///     Err(e) => eprintln!("Error creating file: {}", e),
+/// }
+/// ```
 pub fn safe_create_file(path: &Path, allow_symlinks: bool) -> Result<File> {
     let safe_path = safe_file_path(path, allow_symlinks)?;
     File::create(&safe_path).map_err(Error::from)


### PR DESCRIPTION
This PR prepares the Atlas CLI for publication on crates.io by adding necessary metadata, documentation, and improving the installation docs.

### Changes:
-  Added package metadata to `Cargo.toml` (description, keywords, categories, etc.)
-  Created `src/lib.rs` to enable documentation generation on docs.rs
-  Added documentation tests across public modules
-  Updated README with cargo installation instructions
