### PR TITLE
Updated c2pa-lib to v0.1.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -99,9 +99,9 @@ checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
 
 [[package]]
 name = "atlas-c2pa-lib"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e72e4abc47e1e3ff53ea91db397e1b7ea9f60fccfdcc0b60421caecfe727c0b9"
+checksum = "b61f938fa4f11de6ae3c7e6d9c3ae1bb716d91b2b4eebb10294c7a9891956f3e"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ yaml = []
 with-tdx = ["tdx_workload_attestation/host-gcp-tdx"]
 
 [dependencies]
-atlas-c2pa-lib = { version = "0.1.1" }
+atlas-c2pa-lib = { version = "0.1.2" }
 
 # TDX
 tdx_workload_attestation = { version = "0.1.0", default-features = false }


### PR DESCRIPTION
This PR updates the c2pa-lib dependency to version v0.1.2. Includes upstream improvements and bug fixes from the latest release https://github.com/IntelLabs/atlas-c2pa-lib/releases/tag/v0.1.2